### PR TITLE
update description for refresh job status polling timeout in configSc…

### DIFF
--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -87,7 +87,7 @@
          "type":"integer",
          "title":"Refresh job status polling timeout",
          "default":3600,
-         "description":"Poll the statuses of triggered jobs for the specified number of seconds. The component ends after reaching the timeout value. The maximum timeout is 2 hours.",
+         "description":"Poll the statuses of triggered jobs for the specified number of seconds. The component stops after reaching the timeout value. The maximum timeout is also defined in the settings in the top-right menu.",
          "propertyOrder":550,
          "options":{
             "dependencies":{


### PR DESCRIPTION
This pull request updates the description for the job status polling timeout setting in the `component_config/configSchema.json` file to clarify where the maximum timeout is defined.

Configuration documentation update:

* Updated the `description` for the polling timeout setting to indicate that the maximum timeout is defined in the settings in the top-right menu, rather than being a fixed value.

According to https://keboola.atlassian.net/browse/SUPPORT-12858
