### PR TITLE
feat: add retry mechanism for HTTP 429 rate limit errors

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -23,6 +23,17 @@ STATE_AUTH_ID = "auth_id"
 STATE_REFRESH_TOKEN = "#refresh_token"
 REQUIRED_PARAMETERS = []
 WAIT_BEFORE_STATUS_CHECK = 10  # seconds
+RATE_LIMIT_MAX_RETRIES = 10
+RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
+
+
+class TooManyRequestsError(Exception):
+    """Raised when the API returns HTTP 429 Too Many Requests."""
+    def __init__(self, retry_after: int | None = None):
+        self.retry_after = retry_after
+        super().__init__(
+            f"Rate limited by PowerBI API (HTTP 429). Retry-After: {retry_after}s"
+        )
 
 
 class Component(ComponentBase):
@@ -175,7 +186,29 @@ class Component(ComponentBase):
 
         return response.json()
 
-    @backoff.on_exception(backoff.expo, Exception, max_tries=3)
+    @staticmethod
+    def _get_retry_after(response: requests.models.Response, default: int = RATE_LIMIT_DEFAULT_WAIT) -> int:
+        """Extract wait time in seconds from Retry-After header."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return int(retry_after)
+            except (ValueError, TypeError):
+                pass
+        return default
+
+    def _check_rate_limit(self, response: requests.models.Response) -> None:
+        """Check for HTTP 429 rate limit and raise TooManyRequestsError if detected."""
+        if response.status_code == 429:
+            retry_after = self._get_retry_after(response)
+            logging.warning(
+                f"Rate limited by PowerBI API (HTTP 429). "
+                f"Waiting {retry_after} seconds before retrying..."
+            )
+            time.sleep(retry_after)
+            raise TooManyRequestsError(retry_after=retry_after)
+
+    @backoff.on_exception(backoff.expo, TooManyRequestsError, max_tries=RATE_LIMIT_MAX_RETRIES)
     def refresh_dataset(self, group_url, dataset) -> Union[requests.models.Response, bool]:
         refresh_url = f"https://api.powerbi.com/v1.0/myorg/{group_url}/datasets/{dataset}/refreshes"
         # https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group#limitations
@@ -186,12 +219,15 @@ class Component(ComponentBase):
             if r.status_code == 202:
                 logging.info(f"Dataset {dataset} refresh accepted by PowerBI API.")
                 return r
+            self._check_rate_limit(r)
             msg = json.loads(r.text)
             logging.error(
                 f"Failed to refresh dataset: error code: {msg['error']['code']} "
                 f"message: {msg['error']['message']}")
             return False
 
+        except TooManyRequestsError:
+            raise
         except Exception as e:
             logging.error(f"Dataset refresh failed. Exception: {e}")
             return False
@@ -210,9 +246,11 @@ class Component(ComponentBase):
         refresh_url = f"https://api.powerbi.com/v1.0/myorg/{group_url}/datasets/{dataset_id}/refreshes"
         return self._get_request(refresh_url)
 
-    @backoff.on_exception(backoff.expo, RequestException, max_tries=3)
-    def _get_request(self, url):
+    @backoff.on_exception(backoff.expo, (RequestException, TooManyRequestsError), max_tries=RATE_LIMIT_MAX_RETRIES)
+    def _get_request(self, url: str) -> requests.models.Response:
         response = requests.get(url=url, headers=self.header)
+
+        self._check_rate_limit(response)
 
         if response.status_code == 403:
             try:
@@ -221,6 +259,7 @@ class Component(ComponentBase):
                     access_token, _ = self.get_oauth_token()
                     self.header = access_token
                     response = requests.get(url=url, headers=self.header)
+                    self._check_rate_limit(response)
             except ValueError:
                 raise UserException(f"Request for url {url} failed with status code: {response.status_code}"
                                     f" and message: {response.text}")
@@ -269,7 +308,7 @@ class Component(ComponentBase):
 
                 try:
                     request = self.refresh_status(requestid[0], group_url)
-                except RequestException as e:
+                except (RequestException, TooManyRequestsError) as e:
                     raise UserException(f"Refresh status check failed with exception: {e}")
 
                 self.process_status(request, requestid, success_list, running_list)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -6,9 +6,10 @@ Created on 12. 11. 2018
 import unittest
 import mock
 import os
+from unittest.mock import patch, MagicMock
 from freezegun import freeze_time
 
-from component import Component
+from component import Component, TooManyRequestsError, RATE_LIMIT_DEFAULT_WAIT
 
 
 class TestComponent(unittest.TestCase):
@@ -21,6 +22,207 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestTooManyRequestsError(unittest.TestCase):
+
+    def test_exception_message(self):
+        err = TooManyRequestsError(retry_after=30)
+        self.assertEqual(err.retry_after, 30)
+        self.assertIn("429", str(err))
+        self.assertIn("30", str(err))
+
+    def test_exception_default(self):
+        err = TooManyRequestsError()
+        self.assertIsNone(err.retry_after)
+
+
+class TestGetRetryAfter(unittest.TestCase):
+
+    def test_retry_after_header_present(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "45"}
+        result = Component._get_retry_after(response)
+        self.assertEqual(result, 45)
+
+    def test_retry_after_header_missing(self):
+        response = MagicMock()
+        response.headers = {}
+        result = Component._get_retry_after(response)
+        self.assertEqual(result, RATE_LIMIT_DEFAULT_WAIT)
+
+    def test_retry_after_header_invalid(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "not-a-number"}
+        result = Component._get_retry_after(response)
+        self.assertEqual(result, RATE_LIMIT_DEFAULT_WAIT)
+
+    def test_retry_after_custom_default(self):
+        response = MagicMock()
+        response.headers = {}
+        result = Component._get_retry_after(response, default=120)
+        self.assertEqual(result, 120)
+
+
+class TestCheckRateLimit(unittest.TestCase):
+
+    @patch('component.time.sleep')
+    def test_raises_on_429(self, mock_sleep):
+        """Test that _check_rate_limit raises TooManyRequestsError on 429 response."""
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {"Retry-After": "30"}
+
+        comp = Component.__new__(Component)
+
+        with self.assertRaises(TooManyRequestsError) as ctx:
+            comp._check_rate_limit(response)
+
+        self.assertEqual(ctx.exception.retry_after, 30)
+        mock_sleep.assert_called_once_with(30)
+
+    @patch('component.time.sleep')
+    def test_uses_default_wait(self, mock_sleep):
+        """Test that _check_rate_limit uses default wait when Retry-After is missing."""
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {}
+
+        comp = Component.__new__(Component)
+
+        with self.assertRaises(TooManyRequestsError):
+            comp._check_rate_limit(response)
+
+        mock_sleep.assert_called_once_with(RATE_LIMIT_DEFAULT_WAIT)
+
+    @patch('component.time.sleep')
+    def test_noop_on_200(self, mock_sleep):
+        """Test that _check_rate_limit does nothing for non-429 responses."""
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {}
+
+        comp = Component.__new__(Component)
+        comp._check_rate_limit(response)
+
+        mock_sleep.assert_not_called()
+
+    @patch('component.time.sleep')
+    def test_noop_on_500(self, mock_sleep):
+        """Test that _check_rate_limit does nothing for 500 responses."""
+        response = MagicMock()
+        response.status_code = 500
+        response.headers = {}
+
+        comp = Component.__new__(Component)
+        comp._check_rate_limit(response)
+
+        mock_sleep.assert_not_called()
+
+
+class TestRefreshDatasetRateLimit(unittest.TestCase):
+
+    @patch('component.time.sleep')
+    @patch('component.requests.post')
+    def test_retries_on_429(self, mock_post, mock_sleep):
+        """Test that refresh_dataset retries when it receives a 429 response."""
+        response_429 = MagicMock()
+        response_429.status_code = 429
+        response_429.headers = {"Retry-After": "5"}
+
+        response_202 = MagicMock()
+        response_202.status_code = 202
+        response_202.headers = {"RequestId": "test-request-id"}
+
+        mock_post.side_effect = [response_429, response_202]
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+        result = comp.refresh_dataset("groups/test-workspace", "test-dataset")
+
+        self.assertEqual(result, response_202)
+        self.assertEqual(mock_post.call_count, 2)
+
+    @patch('component.time.sleep')
+    @patch('component.requests.post')
+    def test_returns_false_on_other_errors(self, mock_post, mock_sleep):
+        """Test that refresh_dataset returns False for non-429 error responses."""
+        response_400 = MagicMock()
+        response_400.status_code = 400
+        response_400.headers = {}
+        response_400.text = '{"error": {"code": "BadRequest", "message": "Invalid request"}}'
+
+        mock_post.return_value = response_400
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+        result = comp.refresh_dataset("groups/test-workspace", "test-dataset")
+
+        self.assertFalse(result)
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch('component.time.sleep')
+    @patch('component.requests.post')
+    def test_success_on_202(self, mock_post, mock_sleep):
+        """Test that refresh_dataset returns the response on 202."""
+        response_202 = MagicMock()
+        response_202.status_code = 202
+        response_202.headers = {"RequestId": "test-request-id"}
+
+        mock_post.return_value = response_202
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+        result = comp.refresh_dataset("groups/test-workspace", "test-dataset")
+
+        self.assertEqual(result, response_202)
+        mock_sleep.assert_not_called()
+
+
+class TestGetRequestRateLimit(unittest.TestCase):
+
+    @patch('component.time.sleep')
+    @patch('component.requests.get')
+    def test_retries_on_429(self, mock_get, mock_sleep):
+        """Test that _get_request retries when it receives a 429 response."""
+        response_429 = MagicMock()
+        response_429.status_code = 429
+        response_429.headers = {"Retry-After": "10"}
+
+        response_200 = MagicMock()
+        response_200.status_code = 200
+        response_200.headers = {}
+
+        mock_get.side_effect = [response_429, response_200]
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+        result = comp._get_request("https://api.powerbi.com/v1.0/myorg/test")
+
+        self.assertEqual(result, response_200)
+        self.assertEqual(mock_get.call_count, 2)
+
+    @patch('component.time.sleep')
+    @patch('component.requests.get')
+    def test_success_on_200(self, mock_get, mock_sleep):
+        """Test that _get_request returns response directly on 200."""
+        response_200 = MagicMock()
+        response_200.status_code = 200
+        response_200.headers = {}
+
+        mock_get.return_value = response_200
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test-token", "Content-Type": "application/json"}
+
+        result = comp._get_request("https://api.powerbi.com/v1.0/myorg/test")
+
+        self.assertEqual(result, response_200)
+        mock_sleep.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds retry logic for HTTP 429 (Too Many Requests) responses from the PowerBI API. Previously, 429 errors caused immediate component failure. Now the component waits (respecting the `Retry-After` header) and retries up to 10 times with exponential backoff.

**Changes:**
- New `TooManyRequestsError` exception class for 429 responses
- `_check_rate_limit()` — detects 429, sleeps for `Retry-After` (default 60s), raises for retry
- `_get_retry_after()` — parses `Retry-After` header safely
- `refresh_dataset()` — now retries on 429 instead of returning `False`
- `_get_request()` — now handles 429 on both initial request and post-token-refresh request
- `check_status()` — catches `TooManyRequestsError` alongside `RequestException`
- 15 new unit tests covering all 429 handling paths

## Review & Testing Checklist for Human

- [ ] **Double-wait behavior**: `_check_rate_limit` sleeps for `Retry-After` seconds *and then* `backoff.expo` adds its own exponential delay on top. Verify this compounding wait is acceptable vs. using only one mechanism. In sustained rate-limiting, total wait could be very long.
- [ ] **`_get_request` max_tries increased from 3 to 10**: The `RATE_LIMIT_MAX_RETRIES` constant is now shared for both `RequestException` and `TooManyRequestsError` retries. This means transient network errors also get 10 retries instead of the previous 3. Confirm this side effect is desired.
- [ ] **Exhausted retries behavior**: If all 10 retries fail, `TooManyRequestsError` propagates as a generic exception (exit code 2), not a `UserException` (exit code 1). In `check_status` it's caught and wrapped as `UserException`, but in `run()` → `refresh_dataset()` it is not. Verify this is acceptable.
- [ ] **End-to-end verification**: Unit tests mock the API. Recommend testing with a real PowerBI workspace by triggering rapid successive runs to confirm 429 handling works in practice. The branch image tag can be used with `runtime.tag` in a test config.

### Notes
- The previous `@backoff.on_exception(backoff.expo, Exception, max_tries=3)` on `refresh_dataset` was effectively dead code — the inner `try/except Exception` swallowed all exceptions before backoff could see them. The new code fixes this by re-raising `TooManyRequestsError` before the generic `except Exception` block.
- `RATE_LIMIT_DEFAULT_WAIT = 60` seconds is used when the API doesn't include a `Retry-After` header.

## Release Notes
**Justification, description**

Adds retry mechanism for PowerBI API rate limiting (HTTP 429). The component now waits and retries instead of failing immediately when too many API calls are made in a short period.

**Plans for Customer Communication**

N/A — transparent improvement, no configuration changes needed.

**Impact Analysis**

Low risk. No changes to configuration schema, sync actions, or output behavior. Only affects error handling for 429 responses. Existing non-429 error paths are unchanged.

**Deployment Plan**

Standard deploy via semantic version tag.

**Rollback Plan**

Revert to previous tag if issues arise.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/b3c4967c6dad42038117e286edefe9b5
Requested by: @terezaskalova