### PR TITLE
CFTL-421: Add 429 retry mechanism for Power BI API rate limiting

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -23,6 +23,17 @@ STATE_AUTH_ID = "auth_id"
 STATE_REFRESH_TOKEN = "#refresh_token"
 REQUIRED_PARAMETERS = []
 WAIT_BEFORE_STATUS_CHECK = 10  # seconds
+RATE_LIMIT_MAX_RETRIES = 10
+RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
+
+
+class TooManyRequestsError(Exception):
+    """Raised when the API returns HTTP 429 Too Many Requests."""
+    def __init__(self, retry_after: int | None = None):
+        self.retry_after = retry_after
+        super().__init__(
+            f"Rate limited by PowerBI API (HTTP 429). Retry after: {retry_after}s"
+        )
 
 
 class Component(ComponentBase):
@@ -175,7 +186,34 @@ class Component(ComponentBase):
 
         return response.json()
 
+    @staticmethod
+    def _get_retry_after(response: requests.models.Response, default: int = RATE_LIMIT_DEFAULT_WAIT) -> int:
+        """Extract wait time in seconds from Retry-After header, falling back to default."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return int(retry_after)
+            except (ValueError, TypeError):
+                pass
+        return default
+
+    def _check_rate_limit(self, response: requests.models.Response) -> None:
+        """Raise TooManyRequestsError if the response is HTTP 429."""
+        if response.status_code == 429:
+            retry_after = self._get_retry_after(response)
+            logging.warning(
+                f"Rate limited by PowerBI API (HTTP 429). Retry after {retry_after} seconds."
+            )
+            raise TooManyRequestsError(retry_after=retry_after)
+
     @backoff.on_exception(backoff.expo, Exception, max_tries=3)
+    @backoff.on_exception(
+        backoff.runtime,
+        TooManyRequestsError,
+        value=lambda exc: exc.retry_after if exc.retry_after is not None else RATE_LIMIT_DEFAULT_WAIT,
+        jitter=None,
+        max_tries=RATE_LIMIT_MAX_RETRIES,
+    )
     def refresh_dataset(self, group_url, dataset) -> Union[requests.models.Response, bool]:
         refresh_url = f"https://api.powerbi.com/v1.0/myorg/{group_url}/datasets/{dataset}/refreshes"
         # https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/refresh-dataset-in-group#limitations
@@ -186,12 +224,15 @@ class Component(ComponentBase):
             if r.status_code == 202:
                 logging.info(f"Dataset {dataset} refresh accepted by PowerBI API.")
                 return r
+            self._check_rate_limit(r)
             msg = json.loads(r.text)
             logging.error(
                 f"Failed to refresh dataset: error code: {msg['error']['code']} "
                 f"message: {msg['error']['message']}")
             return False
 
+        except TooManyRequestsError:
+            raise
         except Exception as e:
             logging.error(f"Dataset refresh failed. Exception: {e}")
             return False
@@ -211,8 +252,17 @@ class Component(ComponentBase):
         return self._get_request(refresh_url)
 
     @backoff.on_exception(backoff.expo, RequestException, max_tries=3)
+    @backoff.on_exception(
+        backoff.runtime,
+        TooManyRequestsError,
+        value=lambda exc: exc.retry_after if exc.retry_after is not None else RATE_LIMIT_DEFAULT_WAIT,
+        jitter=None,
+        max_tries=RATE_LIMIT_MAX_RETRIES,
+    )
     def _get_request(self, url):
         response = requests.get(url=url, headers=self.header)
+
+        self._check_rate_limit(response)
 
         if response.status_code == 403:
             try:
@@ -269,7 +319,7 @@ class Component(ComponentBase):
 
                 try:
                     request = self.refresh_status(requestid[0], group_url)
-                except RequestException as e:
+                except (RequestException, TooManyRequestsError) as e:
                     raise UserException(f"Refresh status check failed with exception: {e}")
 
                 self.process_status(request, requestid, success_list, running_list)

--- a/src/component.py
+++ b/src/component.py
@@ -27,7 +27,7 @@ RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
 
 
-class TooManyRequestsError(UserException):
+class TooManyRequestsError(Exception):
     """Raised when the API returns HTTP 429 Too Many Requests."""
     def __init__(self, retry_after: int | None = None):
         self.retry_after = retry_after

--- a/src/component.py
+++ b/src/component.py
@@ -27,7 +27,7 @@ RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
 
 
-class TooManyRequestsError(Exception):
+class TooManyRequestsError(UserException):
     """Raised when the API returns HTTP 429 Too Many Requests."""
     def __init__(self, retry_after: int | None = None):
         self.retry_after = retry_after
@@ -206,7 +206,8 @@ class Component(ComponentBase):
             )
             raise TooManyRequestsError(retry_after=retry_after)
 
-    @backoff.on_exception(backoff.expo, Exception, max_tries=3)
+    @backoff.on_exception(backoff.expo, Exception, max_tries=3,
+                          giveup=lambda e: isinstance(e, TooManyRequestsError))
     @backoff.on_exception(
         backoff.runtime,
         TooManyRequestsError,

--- a/tests/functional/03_run_refresh_429_retry/expected/data/out/state.json
+++ b/tests/functional/03_run_refresh_429_retry/expected/data/out/state.json
@@ -1,0 +1,4 @@
+{
+    "#refresh_token": "REDACTED",
+    "auth_id": "DUMMY_CRED_ID"
+}

--- a/tests/functional/03_run_refresh_429_retry/source/data/cassettes/requests.json
+++ b/tests/functional/03_run_refresh_429_retry/source/data/cassettes/requests.json
@@ -1,0 +1,50 @@
+{
+  "_metadata": {
+    "freeze_time": "2026-03-23T14:00:00",
+    "keboola_vcr_version": "0.3.0",
+    "recorded_at": "2026-03-23T14:00:00.000000+00:00",
+    "note": "Manually crafted cassette. Simulates a 429 Too Many Requests response on the first refresh attempt, followed by a successful 202 on retry. Requires the CFTL-421 retry fix to pass."
+  },
+  "interactions": [
+    {
+      "request": {
+        "body": "client_id=REDACTED&client_secret=REDACTED&grant_type=refresh_token&resource=https%3A%2F%2Fanalysis.windows.net%2Fpowerbi%2Fapi&refresh_token=REDACTED",
+        "headers": {"Accept": ["*/*"], "Content-Length": ["1712"], "Content-Type": ["application/x-www-form-urlencoded"]},
+        "method": "POST",
+        "uri": "https://login.microsoftonline.com/common/oauth2/token"
+      },
+      "response": {
+        "body": {"string": "{\"token_type\": \"Bearer\", \"scope\": \"Dataset.ReadWrite.All Workspace.Read.All\", \"expires_in\": \"3600\", \"ext_expires_in\": \"3600\", \"expires_on\": \"1774281600\", \"not_before\": \"1774278000\", \"resource\": \"https://analysis.windows.net/powerbi/api\", \"access_token\": \"REDACTED\", \"refresh_token\": \"REDACTED\"}"},
+        "headers": {"Content-Length": ["1234"], "Content-Type": ["application/json; charset=utf-8"]},
+        "status": {"code": 200, "message": "OK"}
+      }
+    },
+    {
+      "request": {
+        "body": "notifyOption=MailOnFailure",
+        "headers": {"Accept": ["*/*"], "Content-Length": ["26"], "Content-Type": ["application/json"]},
+        "method": "POST",
+        "uri": "https://api.powerbi.com/v1.0/myorg/groups/27582307-ab04-4269-a6e7-4d1c803ba6ba/datasets/3ad5e537-2352-43f2-a30e-14c6eb11712e/refreshes"
+      },
+      "response": {
+        "body": {"string": "{\"message\":\"You have exceeded the amount of requests allowed in the current time frame and further requests will fail. Retry in 5 seconds.\"}"},
+        "headers": {"Content-Type": ["application/json"], "Retry-After": ["5"]},
+        "status": {"code": 429, "message": "Too Many Requests"}
+      }
+    },
+    {
+      "request": {
+        "body": "notifyOption=MailOnFailure",
+        "headers": {"Accept": ["*/*"], "Content-Length": ["26"], "Content-Type": ["application/json"]},
+        "method": "POST",
+        "uri": "https://api.powerbi.com/v1.0/myorg/groups/27582307-ab04-4269-a6e7-4d1c803ba6ba/datasets/3ad5e537-2352-43f2-a30e-14c6eb11712e/refreshes"
+      },
+      "response": {
+        "body": {"string": ""},
+        "headers": {"Content-Type": ["application/octet-stream"], "content-length": ["0"], "RequestId": ["dummy-request-id-429-retry"]},
+        "status": {"code": 202, "message": "Accepted"}
+      }
+    }
+  ],
+  "version": 1
+}

--- a/tests/functional/03_run_refresh_429_retry/source/data/config.json
+++ b/tests/functional/03_run_refresh_429_retry/source/data/config.json
@@ -1,0 +1,20 @@
+{
+    "parameters": {
+        "workspace": "27582307-ab04-4269-a6e7-4d1c803ba6ba",
+        "dataset_list": [
+            "3ad5e537-2352-43f2-a30e-14c6eb11712e"
+        ],
+        "wait": "No"
+    },
+    "authorization": {
+        "oauth_api": {
+            "credentials": {
+                "id": "DUMMY_CRED_ID",
+                "appKey": "DUMMY_CLIENT_ID",
+                "#appSecret": "DUMMY_CLIENT_SECRET",
+                "#data": "{\"refresh_token\": \"DUMMY_REFRESH_TOKEN\", \"access_token\": \"DUMMY_ACCESS_TOKEN\"}"
+            }
+        }
+    },
+    "action": "run"
+}

--- a/tests/functional/03_run_refresh_429_retry/source/data/in/state.json
+++ b/tests/functional/03_run_refresh_429_retry/source/data/in/state.json
@@ -1,0 +1,4 @@
+{
+    "#refresh_token": "DUMMY_REFRESH_TOKEN",
+    "auth_id": "DUMMY_CRED_ID"
+}

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -6,9 +6,10 @@ Created on 12. 11. 2018
 import unittest
 import mock
 import os
+from unittest.mock import patch, MagicMock
 from freezegun import freeze_time
 
-from component import Component
+from component import Component, TooManyRequestsError, RATE_LIMIT_DEFAULT_WAIT
 
 
 class TestComponent(unittest.TestCase):
@@ -21,6 +22,135 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestTooManyRequestsError(unittest.TestCase):
+
+    def test_message_includes_retry_after(self):
+        err = TooManyRequestsError(retry_after=23)
+        self.assertEqual(err.retry_after, 23)
+        self.assertIn("429", str(err))
+        self.assertIn("23", str(err))
+
+    def test_none_retry_after(self):
+        err = TooManyRequestsError()
+        self.assertIsNone(err.retry_after)
+
+
+class TestGetRetryAfter(unittest.TestCase):
+
+    def test_parses_header(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "23"}
+        self.assertEqual(Component._get_retry_after(response), 23)
+
+    def test_falls_back_to_default_when_missing(self):
+        response = MagicMock()
+        response.headers = {}
+        self.assertEqual(Component._get_retry_after(response), RATE_LIMIT_DEFAULT_WAIT)
+
+    def test_falls_back_to_default_when_invalid(self):
+        response = MagicMock()
+        response.headers = {"Retry-After": "soon"}
+        self.assertEqual(Component._get_retry_after(response), RATE_LIMIT_DEFAULT_WAIT)
+
+    def test_custom_default(self):
+        response = MagicMock()
+        response.headers = {}
+        self.assertEqual(Component._get_retry_after(response, default=120), 120)
+
+
+class TestCheckRateLimit(unittest.TestCase):
+
+    def test_raises_on_429(self):
+        response = MagicMock()
+        response.status_code = 429
+        response.headers = {"Retry-After": "23"}
+        comp = Component.__new__(Component)
+        with self.assertRaises(TooManyRequestsError) as ctx:
+            comp._check_rate_limit(response)
+        self.assertEqual(ctx.exception.retry_after, 23)
+
+    def test_noop_on_200(self):
+        response = MagicMock()
+        response.status_code = 200
+        comp = Component.__new__(Component)
+        comp._check_rate_limit(response)  # should not raise
+
+    def test_noop_on_202(self):
+        response = MagicMock()
+        response.status_code = 202
+        comp = Component.__new__(Component)
+        comp._check_rate_limit(response)  # should not raise
+
+
+class TestRefreshDataset429(unittest.TestCase):
+
+    @patch('time.sleep')
+    @patch('component.requests.post')
+    def test_retries_on_429_then_succeeds(self, mock_post, mock_sleep):
+        response_429 = MagicMock()
+        response_429.status_code = 429
+        response_429.headers = {"Retry-After": "23"}
+
+        response_202 = MagicMock()
+        response_202.status_code = 202
+        response_202.headers = {"RequestId": "test-id"}
+
+        mock_post.side_effect = [response_429, response_202]
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test", "Content-Type": "application/json"}
+
+        result = comp.refresh_dataset("groups/workspace-id", "dataset-id")
+
+        self.assertEqual(result, response_202)
+        self.assertEqual(mock_post.call_count, 2)
+        mock_sleep.assert_called_once_with(23)
+
+    @patch('time.sleep')
+    @patch('component.requests.post')
+    def test_returns_false_on_non_429_error(self, mock_post, mock_sleep):
+        response_400 = MagicMock()
+        response_400.status_code = 400
+        response_400.headers = {}
+        response_400.text = '{"error": {"code": "BadRequest", "message": "Invalid"}}'
+
+        mock_post.return_value = response_400
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test", "Content-Type": "application/json"}
+
+        result = comp.refresh_dataset("groups/workspace-id", "dataset-id")
+
+        self.assertFalse(result)
+        self.assertEqual(mock_post.call_count, 1)
+        mock_sleep.assert_not_called()
+
+
+class TestGetRequest429(unittest.TestCase):
+
+    @patch('time.sleep')
+    @patch('component.requests.get')
+    def test_retries_on_429_then_succeeds(self, mock_get, mock_sleep):
+        response_429 = MagicMock()
+        response_429.status_code = 429
+        response_429.headers = {"Retry-After": "23"}
+
+        response_200 = MagicMock()
+        response_200.status_code = 200
+        response_200.headers = {}
+
+        mock_get.side_effect = [response_429, response_200]
+
+        comp = Component.__new__(Component)
+        comp._header = {"Authorization": "Bearer test", "Content-Type": "application/json"}
+
+        result = comp._get_request("https://api.powerbi.com/v1.0/myorg/test")
+
+        self.assertEqual(result, response_200)
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once_with(23)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes [CFTL-421](https://linear.app/keboola/issue/CFTL-421) / SUPPORT-15631.

Customers occasionally hit HTTP 429 from the Power BI API:
> `Failed to refresh dataset... status code: 429 ... Retry in 23 seconds.`

- Add `TooManyRequestsError` exception carrying the `retry_after` value
- Add `_get_retry_after()` to parse the `Retry-After` response header
- Add `_check_rate_limit()` to detect 429 and raise `TooManyRequestsError`
- `refresh_dataset`: stacked backoff — outer retries generic exceptions (max 3), inner uses `backoff.runtime` to wait exactly `Retry-After` seconds on 429 (max 10 retries)
- `_get_request`: same stacked backoff pattern
- `check_status`: catches `TooManyRequestsError` if all retries are exhausted and surfaces it as `UserException`

## vs Devin's PR #5

Devin's implementation has a double-wait bug: `_check_rate_limit` calls `time.sleep(retry_after)` **and then** `backoff.expo` adds its own exponential delay on top. This implementation uses `backoff.runtime` with `value=lambda exc: exc.retry_after` so the wait time comes directly from the API header — no double sleeping.

## Test plan

- [ ] 13 unit tests pass (`python -m pytest tests/test_component.py -q`)
- [ ] Retry tests verify `time.sleep` is called with the exact `Retry-After` value
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)