### PR TITLE
Defensive fix: handle missing serviceExceptionJson in kds-team.app-powerbi-refresh

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -322,7 +322,10 @@ class Component(ComponentBase):
             logging.debug("PowerBI refresh history did not contain the expected error detail, falling back.")
 
         for entry in entries:
-            if request_id and isinstance(entry, dict) and request_id in entry.get("requestId", ""):
+            if not isinstance(entry, dict):
+                continue
+            entry_request_id = entry.get("requestId")
+            if request_id and isinstance(entry_request_id, str) and request_id in entry_request_id:
                 return entry.get("serviceExceptionJson") or NO_FAILURE_DETAIL
 
         return NO_FAILURE_DETAIL

--- a/src/component.py
+++ b/src/component.py
@@ -24,6 +24,7 @@ REQUIRED_PARAMETERS = []
 WAIT_BEFORE_STATUS_CHECK = 10  # seconds
 RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
+NO_FAILURE_DETAIL = "no error detail provided by the PowerBI API"
 
 
 class TooManyRequestsError(Exception):
@@ -296,6 +297,36 @@ class Component(ComponentBase):
 
         return response
 
+    @staticmethod
+    def _get_failure_detail(response: requests.models.Response, request_id: str) -> str:
+        """
+        Best-effort extraction of the PowerBI failure detail from a refresh-history response.
+
+        `serviceExceptionJson` is optional in the PowerBI refresh-history payload, so reading it
+        directly raises KeyError (or IndexError on a short history) and turns a user-actionable
+        refresh failure into an opaque internal error while the UserException message is being
+        built. The original lookup is attempted first, so the message is unchanged whenever it
+        succeeds; otherwise this falls back to the detail of the refresh entry actually being
+        polled, and finally to a plain placeholder.
+        """
+        try:
+            entries = json.loads(response.content)["value"]
+        except (ValueError, KeyError, TypeError):
+            entries = []
+        if not isinstance(entries, list):
+            entries = []
+
+        try:
+            return entries[1]["serviceExceptionJson"]
+        except (KeyError, IndexError, TypeError):
+            logging.debug("PowerBI refresh history did not contain the expected error detail, falling back.")
+
+        for entry in entries:
+            if request_id and isinstance(entry, dict) and request_id in entry.get("requestId", ""):
+                return entry.get("serviceExceptionJson") or NO_FAILURE_DETAIL
+
+        return NO_FAILURE_DETAIL
+
     def process_status(self, request, request_list, success_list, running_list):
         if request.status_code != 200:
             raise UserException(
@@ -323,11 +354,9 @@ class Component(ComponentBase):
             self.failed_list.append(request_list[0])
             self.requestid_array.remove([request_list[0], request_list[1]])
             if not self.alldatasets:
-                content = json.loads(request.content)
+                failure_detail = self._get_failure_detail(request, request_list[1])
                 failed_display = [self._get_dataset_name(d) for d in self.failed_list]
-                raise UserException(
-                    f"Dataset {failed_display} finished with error {content['value'][1]['serviceExceptionJson']}"
-                )
+                raise UserException(f"Dataset {failed_display} finished with error {failure_detail}")
         elif status == "Disabled":
             logging.info(f"Dataset {self._get_dataset_name(request_list[0])} is disabled")
             self.requestid_array.remove([request_list[0], request_list[1]])

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -189,6 +189,17 @@ class TestGetFailureDetail(unittest.TestCase):
         )
         self.assertEqual(Component._get_failure_detail(response, "req-0"), NO_FAILURE_DETAIL)
 
+    def test_placeholder_when_request_id_is_not_a_string(self):
+        """The helper must never raise, even on a null/non-string requestId."""
+        response = _history_response(
+            [
+                {"requestId": None, "status": "Failed"},
+                {"requestId": 42, "status": "Failed"},
+                "not-a-dict",
+            ]
+        )
+        self.assertEqual(Component._get_failure_detail(response, "req-0"), NO_FAILURE_DETAIL)
+
     def test_placeholder_on_malformed_payload(self):
         response = MagicMock()
         response.content = b"not json at all"

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,11 +1,13 @@
+import json
 import os
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from freezegun import freeze_time
+from keboola.component.exceptions import UserException
 
-from component import RATE_LIMIT_DEFAULT_WAIT, Component, TooManyRequestsError
+from component import NO_FAILURE_DETAIL, RATE_LIMIT_DEFAULT_WAIT, Component, TooManyRequestsError
 
 
 class TestComponent(unittest.TestCase):
@@ -141,6 +143,90 @@ class TestGetRequest429(unittest.TestCase):
         self.assertEqual(result, response_200)
         self.assertEqual(mock_get.call_count, 2)
         mock_sleep.assert_called_once_with(23)
+
+
+def _history_response(entries) -> MagicMock:
+    """Builds a mock PowerBI refresh-history response with the given `value` entries."""
+    response = MagicMock()
+    response.status_code = 200
+    response.content = json.dumps({"value": entries}).encode()
+    response.json.return_value = {"value": entries}
+    return response
+
+
+class TestGetFailureDetail(unittest.TestCase):
+    """`serviceExceptionJson` is optional in the PowerBI refresh-history payload."""
+
+    def test_returns_detail_from_original_lookup(self):
+        response = _history_response(
+            [
+                {"requestId": "req-0", "status": "Completed"},
+                {"requestId": "req-1", "status": "Failed", "serviceExceptionJson": "boom-at-index-1"},
+            ]
+        )
+        self.assertEqual(Component._get_failure_detail(response, "req-1"), "boom-at-index-1")
+
+    def test_falls_back_to_polled_request_when_detail_missing(self):
+        response = _history_response(
+            [
+                {"requestId": "req-0", "status": "Completed"},
+                {"requestId": "req-1", "status": "Failed"},  # no serviceExceptionJson
+                {"requestId": "req-2", "status": "Failed", "serviceExceptionJson": "boom-for-req-2"},
+            ]
+        )
+        self.assertEqual(Component._get_failure_detail(response, "req-2"), "boom-for-req-2")
+
+    def test_placeholder_when_history_has_single_entry(self):
+        response = _history_response([{"requestId": "req-0", "status": "Failed"}])
+        self.assertEqual(Component._get_failure_detail(response, "req-0"), NO_FAILURE_DETAIL)
+
+    def test_placeholder_when_no_entry_carries_a_detail(self):
+        response = _history_response(
+            [
+                {"requestId": "req-0", "status": "Failed"},
+                {"requestId": "req-1", "status": "Failed"},
+            ]
+        )
+        self.assertEqual(Component._get_failure_detail(response, "req-0"), NO_FAILURE_DETAIL)
+
+    def test_placeholder_on_malformed_payload(self):
+        response = MagicMock()
+        response.content = b"not json at all"
+        self.assertEqual(Component._get_failure_detail(response, "req-0"), NO_FAILURE_DETAIL)
+
+
+class TestProcessStatusFailedRaisesUserException(unittest.TestCase):
+    """A failed PowerBI refresh must exit 1 with a readable message, never a bare KeyError (exit 2)."""
+
+    @staticmethod
+    def _component() -> Component:
+        comp = Component.__new__(Component)
+        comp.failed_list = []
+        comp.alldatasets = False
+        comp.dataset_names = {}
+        comp.requestid_array = [["dataset-id", "req-1"]]
+        return comp
+
+    def test_raises_user_exception_with_detail(self):
+        comp = self._component()
+        response = _history_response(
+            [
+                {"requestId": "req-0", "status": "Completed"},
+                {"requestId": "req-1", "status": "Failed", "serviceExceptionJson": "boom-at-index-1"},
+            ]
+        )
+        with self.assertRaises(UserException) as ctx:
+            comp.process_status(response, ["dataset-id", "req-1"], [], [])
+        self.assertIn("boom-at-index-1", str(ctx.exception))
+
+    def test_raises_user_exception_when_detail_is_absent(self):
+        """Regression: this payload used to raise KeyError('serviceExceptionJson') and exit 2."""
+        comp = self._component()
+        response = _history_response([{"requestId": "req-1", "status": "Failed"}])
+        with self.assertRaises(UserException) as ctx:
+            comp.process_status(response, ["dataset-id", "req-1"], [], [])
+        self.assertIn(NO_FAILURE_DETAIL, str(ctx.exception))
+        self.assertIn("dataset-id", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds defensive handling for an unhandled `KeyError` observed in production. A
user-actionable PowerBI refresh failure was surfacing as an opaque **internal error
(exit 2)** instead of a readable `UserException` (exit 1). No change to the component's
behaviour on inputs that already worked.

## Root cause

`KeyError: 'serviceExceptionJson'` at `src/component.py:329` (pre-change line numbering).

When a dataset refresh came back with status `Failed`, `process_status()` built its
`UserException` message by reading `content['value'][1]['serviceExceptionJson']` directly
out of the refresh-history payload. That field is **optional** in the PowerBI
`Get Refresh History` API, so on a failed refresh that carries no service exception the
lookup raised `KeyError('serviceExceptionJson')` — and on a history with fewer than two
entries, `IndexError` — *while the error message was being constructed*.

Because the exception escaped while building the `UserException`, it fell through to the
entrypoint's generic `except Exception` handler and the job exited **2**. The only
artifact was the bare string `'serviceExceptionJson'` (the `str()` of the `KeyError`),
which is exactly what the runner logged:

```
container '...-kds-team-app-powerbi-refresh' failed: (2) 'serviceExceptionJson'
```

So the team got paged for an "internal error", and the customer got no indication that
their PowerBI-side refresh had simply failed.

Classified as **deterministic-but-defensible** (user-actionable failure surfacing as an
internal error). **6 occurrences over the last 30 days**, all with the identical
signature.

Reproduced locally against the pre-change code:

| refresh-history payload | before | after |
|---|---|---|
| 2 entries, `serviceExceptionJson` present | `UserException` (exit 1) | **identical** `UserException` |
| 2 entries, field absent | `KeyError: 'serviceExceptionJson'` → exit 2 | `UserException` (exit 1) |
| 1 entry | `IndexError: list index out of range` → exit 2 | `UserException` (exit 1) |

## Fix

Extraction moved into a new `_get_failure_detail()` helper that **attempts the original
lookup first**, so the message is byte-identical whenever it previously succeeded. Only
when that lookup raises does it degrade — first to the `serviceExceptionJson` of the
refresh entry actually being polled (matched on `requestId`, the same matching the
polling loop already does), and finally to a plain placeholder string.

The narrow `except` clauses cover exactly the exceptions the root cause produces
(`KeyError`, `IndexError`, `TypeError`, `ValueError`) and guard **only message
construction** — never a real failure.

## Behaviour impact: none — defensive-only

- Happy path unchanged; no outputs, transforms, schema, or config semantics touched.
- **The job still fails.** This only changes *how* it fails: a `UserException` (exit 1)
  with a readable message instead of an opaque exit-2 internal error. Nothing is
  converted into a silent success.
- Any payload that previously produced an error message produces the **byte-identical**
  message — the original lookup is still tried first.
- All other status branches (`Completed` / `Disabled` / `Unknown`), plus the
  `failed_list` / `requestid_array` bookkeeping, are untouched.
- Existing tests pass unchanged — no assertions modified or deleted.

### Deliberately left alone

The `[1]` index into the refresh history is a pre-existing oddity (the failed refresh
being polled is not necessarily the second history entry). Correcting it would change the
message text on payloads that work today, so it is **out of scope** for a defensive-only
change and left as-is — the new fallback path matches on `requestId` without altering the
primary lookup.

Likewise, the pre-existing status-selection line in `process_status()`
(`... if request_list[1] in f["requestId"]`) would itself raise on a payload with a null
or non-string `requestId`. That is happy-path logic and is left untouched here; see the
review thread on `_get_failure_detail` for the reasoning.

## Evidence

Datadog monitor: https://app.datadoghq.eu/monitors/97152903

## Tests

`uv run pytest` green — **24 passed** (16 pre-existing + 8 added). `ruff format` and
`ruff check` clean.

Added regression coverage:

- `TestGetFailureDetail` — the original lookup still wins when the field is present; the
  fallback finds the polled request's detail; the placeholder is used for a
  single-entry history, a history where no entry carries a detail, a null/non-string
  `requestId`, and a malformed (non-JSON) payload.
- `TestProcessStatusFailedRaisesUserException` — `process_status()` raises `UserException`
  (never a bare `KeyError`) both when the detail is present and when it is absent. The
  second case is the direct regression test for this alert: that payload raised
  `KeyError('serviceExceptionJson')` before the change.

## Note on CI

Open dependabot PRs on this repo fail the pipeline at the deploy-credential step — a
pre-existing, dependabot-token-scoping issue unrelated to this branch. The last pipeline
run on `main` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)