### PR TITLE
feat: optional tenant_id for OAuth token authority (SUPPORT-17248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ PowerBI Refresh Configuration
  - **Wait for all datasets** (`alldatasets`) - [OPT] End the job with an error if any dataset fails to refresh (only works when "Wait for end" is set to `Yes`).
  - **Interval** (`interval`) - [OPT] Status check interval (only works when "Wait for end" is set to `Yes`).
  - **Timeout** (`timeout`) - [OPT] Status check timeout (only works when "Wait for end" is `Yes`).
- - **Tenant ID** (`tenant_id`) - [OPT] Advanced. Leave blank unless you authorized with an external (B2B guest) account. By default the token is requested from the `common` authority, which resolves to the signed-in user's *home* tenant; for a guest account that is not the tenant hosting the workspace, so its workspaces and datasets are not visible and refreshes fail. Set this to the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace. Enter the bare identifier, not a full URL.
+ - **Tenant ID** (`tenant_id`) - [OPT] Leave blank unless you authorized with an external (B2B guest) account. By default the token is requested from the `common` authority, which resolves to the signed-in user's *home* tenant; for a guest account that is not the tenant hosting the workspace, so its workspaces and datasets are not visible and refreshes fail. Set this to the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace. Enter the bare identifier, not a full URL.
 
 ### Using a B2B guest account
 
-If the workspace lives in a tenant you are only a guest in, set **Tenant ID** to that tenant's identifier. If refreshes still fail with a token error immediately after setting it, re-run the OAuth authorization for the configuration so a fresh token is issued for that tenant.
+If the workspace lives in a tenant you are only a guest in, set **Tenant ID** to that tenant's identifier.
+
+Set it **before** using *Load workspaces* and *Reload dataset names*. Those pickers enumerate whichever tenant the token points at, so with the field still blank they list your own home tenant's workspaces — and they do so without any error, which is what makes this failure mode hard to spot. If you already picked a workspace or dataset before setting **Tenant ID**, reload both lists and select again.
+
+If refreshes still fail with a token error immediately after setting it, re-run the OAuth authorization for the configuration so a fresh token is issued for that tenant.
 
 Sample Configuration
 =============

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you need additional endpoints, please submit your request at [ideas.keboola.c
 PowerBI Refresh Configuration
 =============
 
+ - **Tenant ID** (`tenant_id`) - [OPT] Microsoft Entra tenant ID of the tenant hosting the workspace. Required when authorizing with an external (B2B guest) account, since the default `common` authority resolves to the guest's home tenant. Leave blank to use the default.
  - **PowerBI workspace** (`workspace`) - [REQ] Leave this blank if exporting to the signed-in account's workspace.
  - **PowerBI datasets** (`datasets`) - [REQ] Enter the **ID** of the dataset (not the dataset name).
  - **Wait for end** (`wait`) - [OPT] Check the dataset's refresh status after sending the refresh request.

--- a/README.md
+++ b/README.md
@@ -29,13 +29,17 @@ If you need additional endpoints, please submit your request at [ideas.keboola.c
 PowerBI Refresh Configuration
 =============
 
- - **Tenant ID** (`tenant_id`) - [OPT] Microsoft Entra tenant ID of the tenant hosting the workspace. Required when authorizing with an external (B2B guest) account, since the default `common` authority resolves to the guest's home tenant. Leave blank to use the default.
  - **PowerBI workspace** (`workspace`) - [REQ] Leave this blank if exporting to the signed-in account's workspace.
  - **PowerBI datasets** (`datasets`) - [REQ] Enter the **ID** of the dataset (not the dataset name).
  - **Wait for end** (`wait`) - [OPT] Check the dataset's refresh status after sending the refresh request.
  - **Wait for all datasets** (`alldatasets`) - [OPT] End the job with an error if any dataset fails to refresh (only works when "Wait for end" is set to `Yes`).
  - **Interval** (`interval`) - [OPT] Status check interval (only works when "Wait for end" is set to `Yes`).
  - **Timeout** (`timeout`) - [OPT] Status check timeout (only works when "Wait for end" is `Yes`).
+ - **Tenant ID** (`tenant_id`) - [OPT] Advanced. Leave blank unless you authorized with an external (B2B guest) account. By default the token is requested from the `common` authority, which resolves to the signed-in user's *home* tenant; for a guest account that is not the tenant hosting the workspace, so its workspaces and datasets are not visible and refreshes fail. Set this to the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace. Enter the bare identifier, not a full URL.
+
+### Using a B2B guest account
+
+If the workspace lives in a tenant you are only a guest in, set **Tenant ID** to that tenant's identifier. If refreshes still fail with a token error immediately after setting it, re-run the OAuth authorization for the configuration so a fresh token is issued for that tenant.
 
 Sample Configuration
 =============

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -97,9 +97,9 @@
       },
       "tenant_id":{
          "type":"string",
-         "title":"Tenant ID (advanced, optional)",
-         "description":"Leave blank unless you authorized with an external (B2B guest) account. In that case enter the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace - the default authority resolves to the guest's own home tenant, so workspaces and datasets of the hosting tenant would not be found.",
-         "propertyOrder":600,
+         "title":"Tenant ID (optional, external/B2B guest accounts only)",
+         "description":"Leave blank unless you authorized with an external (B2B guest) account. In that case enter the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace - the default authority resolves to the guest's own home tenant, so workspaces and datasets of the hosting tenant would not be found. Set this before loading the workspace and dataset lists below, as those list whichever tenant this field points at.",
+         "propertyOrder":150,
          "default":""
       }
    }

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -3,13 +3,6 @@
    "title":"PowerBI Refresh Configuration",
    "required":[],
    "properties":{
-      "tenant_id":{
-         "type":"string",
-         "title":"Tenant ID",
-         "description":"Microsoft Entra tenant ID of the tenant hosting the workspace. Required when authorizing with an external (B2B guest) account, since the default authority resolves to the guest's home tenant. Leave blank to use the default.",
-         "propertyOrder":150,
-         "default":""
-      },
       "workspace":{
          "type":"string",
          "format": "select",
@@ -101,6 +94,13 @@
                "wait":"Yes"
             }
          }
+      },
+      "tenant_id":{
+         "type":"string",
+         "title":"Tenant ID (advanced, optional)",
+         "description":"Leave blank unless you authorized with an external (B2B guest) account. In that case enter the Microsoft Entra tenant ID (GUID) or domain name of the tenant hosting the workspace - the default authority resolves to the guest's own home tenant, so workspaces and datasets of the hosting tenant would not be found.",
+         "propertyOrder":600,
+         "default":""
       }
    }
 }

--- a/component_config/configSchema.json
+++ b/component_config/configSchema.json
@@ -3,6 +3,13 @@
    "title":"PowerBI Refresh Configuration",
    "required":[],
    "properties":{
+      "tenant_id":{
+         "type":"string",
+         "title":"Tenant ID",
+         "description":"Microsoft Entra tenant ID of the tenant hosting the workspace. Required when authorizing with an external (B2B guest) account, since the default authority resolves to the guest's home tenant. Leave blank to use the default.",
+         "propertyOrder":150,
+         "default":""
+      },
       "workspace":{
          "type":"string",
          "format": "select",

--- a/src/component.py
+++ b/src/component.py
@@ -5,6 +5,7 @@ Template Component main class.
 
 import json
 import logging
+import re
 import time
 from datetime import datetime  # noqa
 
@@ -28,6 +29,10 @@ WAIT_BEFORE_STATUS_CHECK = 10  # seconds
 RATE_LIMIT_MAX_RETRIES = 10
 RATE_LIMIT_DEFAULT_WAIT = 60  # seconds
 NO_FAILURE_DETAIL = "no error detail provided by the PowerBI API"
+# Entra accepts either a tenant GUID or a domain name as the authority. Anything with URL
+# structure (scheme, slash, query, fragment, whitespace) would silently mis-target the token
+# endpoint, so it is rejected up front rather than sent to Microsoft.
+TENANT_ID_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$")
 
 
 class TooManyRequestsError(Exception):
@@ -52,7 +57,7 @@ class Component(ComponentBase):
         parameters = self.configuration.parameters
 
         self.workspace = parameters.get("workspace")
-        self.tenant_id = (parameters.get(KEY_TENANT_ID) or "").strip() or DEFAULT_AUTHORITY
+        self.tenant_id = self._resolve_tenant_id(parameters.get(KEY_TENANT_ID))
         self.wait = parameters.get("wait", "No") == "Yes"
         self.timeout = time.time() + parameters.get("timeout", 7200)
         self.interval = parameters.get("interval")
@@ -189,6 +194,27 @@ class Component(ComponentBase):
         return refresh_token
 
     @staticmethod
+    def _resolve_tenant_id(raw_tenant_id) -> str:
+        """Resolves the Entra authority to request the token from.
+
+        Blank or missing keeps the historical `common` authority, so existing configurations
+        are unaffected. A non-empty value must be a bare tenant identifier.
+        """
+        tenant_id = str(raw_tenant_id or "").strip()
+        if not tenant_id:
+            return DEFAULT_AUTHORITY
+
+        if not TENANT_ID_PATTERN.fullmatch(tenant_id):
+            raise UserException(
+                f"Tenant ID '{tenant_id}' is not a valid Microsoft Entra tenant identifier. "
+                "Use the tenant's GUID (e.g. '11111111-2222-3333-4444-555555555555') or its "
+                "domain name (e.g. 'contoso.onmicrosoft.com') - not a full URL, and without "
+                "spaces, slashes, '?' or '#'. Leave the field blank to use the default authority."
+            )
+
+        return tenant_id
+
+    @staticmethod
     def _request_new_token(client_id, client_secret, refresh_token, tenant_id=DEFAULT_AUTHORITY):
         """Requests a new access token using the refresh token from the given tenant authority."""
         url = f"https://login.microsoftonline.com/{tenant_id or DEFAULT_AUTHORITY}/oauth2/token"
@@ -203,9 +229,14 @@ class Component(ComponentBase):
 
         response = requests.post(url, headers=headers, data=payload)
         if response.status_code != 200:
+            try:
+                detail = response.json()
+            except ValueError:
+                # Some error responses from the token endpoint carry an empty or non-JSON body.
+                detail = response.text.strip() or NO_FAILURE_DETAIL
             raise UserException(
                 f"Unable to refresh access token. Status code: {response.status_code} "
-                f"Reason: {response.reason}, message: {response.json()}"
+                f"Reason: {response.reason}, message: {detail}"
             )
 
         return response.json()

--- a/src/component.py
+++ b/src/component.py
@@ -17,6 +17,9 @@ from requests import RequestException
 # configuration variables
 KEY_DATASET = "dataset_list"
 KEY_WORKSPACE = "workspace"
+KEY_TENANT_ID = "tenant_id"
+
+DEFAULT_AUTHORITY = "common"
 
 STATE_AUTH_ID = "auth_id"
 STATE_REFRESH_TOKEN = "#refresh_token"
@@ -49,6 +52,7 @@ class Component(ComponentBase):
         parameters = self.configuration.parameters
 
         self.workspace = parameters.get("workspace")
+        self.tenant_id = (parameters.get(KEY_TENANT_ID) or "").strip() or DEFAULT_AUTHORITY
         self.wait = parameters.get("wait", "No") == "Yes"
         self.timeout = time.time() + parameters.get("timeout", 7200)
         self.interval = parameters.get("interval")
@@ -167,7 +171,7 @@ class Component(ComponentBase):
         auth_id = state_file.get(STATE_AUTH_ID, [])
 
         refresh_token = self._get_refresh_token(auth_id, refresh_token, encrypted_data, credentials)
-        response = self._request_new_token(client_id, client_secret, refresh_token)
+        response = self._request_new_token(client_id, client_secret, refresh_token, self.tenant_id)
 
         return response["access_token"], response["refresh_token"]
 
@@ -185,9 +189,9 @@ class Component(ComponentBase):
         return refresh_token
 
     @staticmethod
-    def _request_new_token(client_id, client_secret, refresh_token):
-        """Requests a new access token using the refresh token."""
-        url = "https://login.microsoftonline.com/common/oauth2/token"
+    def _request_new_token(client_id, client_secret, refresh_token, tenant_id=DEFAULT_AUTHORITY):
+        """Requests a new access token using the refresh token from the given tenant authority."""
+        url = f"https://login.microsoftonline.com/{tenant_id or DEFAULT_AUTHORITY}/oauth2/token"
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         payload = {
             "client_id": client_id,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -260,6 +260,62 @@ class TestTokenAuthority(unittest.TestCase):
     def test_uses_tenant_specific_authority(self):
         self.assertEqual(self._post_url("tenant-guid"), "https://login.microsoftonline.com/tenant-guid/oauth2/token")
 
+    def test_error_response_with_empty_body_raises_user_exception(self):
+        """Regression: an empty/non-JSON error body used to raise JSONDecodeError and exit 2."""
+        response = MagicMock(status_code=404, reason="Not Found", text="")
+        response.json.side_effect = ValueError("no json")
+        with patch("component.requests.post", return_value=response):
+            with self.assertRaises(UserException) as ctx:
+                Component._request_new_token("client", "secret", "refresh", tenant_id="contoso.onmicrosoft.com")
+        self.assertIn("404", str(ctx.exception))
+        self.assertIn(NO_FAILURE_DETAIL, str(ctx.exception))
+
+    def test_error_response_with_text_body_surfaces_text(self):
+        response = MagicMock(status_code=500, reason="Server Error", text="  upstream exploded  ")
+        response.json.side_effect = ValueError("no json")
+        with patch("component.requests.post", return_value=response):
+            with self.assertRaises(UserException) as ctx:
+                Component._request_new_token("client", "secret", "refresh")
+        self.assertIn("upstream exploded", str(ctx.exception))
+
+
+class TestResolveTenantId(unittest.TestCase):
+    """Blank keeps the historical `common` authority; malformed input fails cleanly, not with a traceback."""
+
+    def test_missing_and_blank_values_default_to_common(self):
+        for raw in (None, "", "   ", False, 0):
+            with self.subTest(raw=raw):
+                self.assertEqual(Component._resolve_tenant_id(raw), "common")
+
+    def test_strips_surrounding_whitespace(self):
+        self.assertEqual(Component._resolve_tenant_id("  contoso.onmicrosoft.com  "), "contoso.onmicrosoft.com")
+
+    def test_accepts_guid_and_domain(self):
+        for raw in ("11111111-2222-3333-4444-555555555555", "contoso.onmicrosoft.com", "common"):
+            with self.subTest(raw=raw):
+                self.assertEqual(Component._resolve_tenant_id(raw), raw)
+
+    def test_non_string_truthy_value_does_not_crash(self):
+        """A config written via the API could supply a number; it must not raise AttributeError."""
+        self.assertEqual(Component._resolve_tenant_id(12345), "12345")
+
+    def test_rejects_url_structured_values(self):
+        malformed = [
+            "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/",
+            "common/oauth2/token",
+            "common?x=",
+            "common#frag",
+            "../../foo",
+            "two words",
+            "tenant\nid",
+            "-leading-dash-is-not-a-tenant-",
+        ]
+        for raw in malformed:
+            with self.subTest(raw=raw):
+                with self.assertRaises(UserException) as ctx:
+                    Component._resolve_tenant_id(raw)
+                self.assertIn("not a valid Microsoft Entra tenant identifier", str(ctx.exception))
+
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -240,6 +240,27 @@ class TestProcessStatusFailedRaisesUserException(unittest.TestCase):
         self.assertIn("dataset-id", str(ctx.exception))
 
 
+class TestTokenAuthority(unittest.TestCase):
+    """The token authority must be configurable to support B2B guest accounts."""
+
+    @staticmethod
+    def _post_url(tenant_id=None) -> str:
+        kwargs = {} if tenant_id is None else {"tenant_id": tenant_id}
+        with patch("component.requests.post") as post:
+            post.return_value = MagicMock(status_code=200, json=lambda: {"access_token": "a", "refresh_token": "r"})
+            Component._request_new_token("client", "secret", "refresh", **kwargs)
+        return post.call_args[0][0]
+
+    def test_defaults_to_common_authority(self):
+        self.assertEqual(self._post_url(), "https://login.microsoftonline.com/common/oauth2/token")
+
+    def test_blank_tenant_falls_back_to_common(self):
+        self.assertEqual(self._post_url(""), "https://login.microsoftonline.com/common/oauth2/token")
+
+    def test_uses_tenant_specific_authority(self):
+        self.assertEqual(self._post_url("tenant-guid"), "https://login.microsoftonline.com/tenant-guid/oauth2/token")
+
+
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #18 — the OAuth token was always requested from the hardcoded `/common` authority, which for an Entra B2B guest resolves to the guest's **home** tenant. The resulting token carries `tid` = home tenant, so `GET/POST /v1.0/myorg/...` targets the wrong organization: workspace dropdowns list the guest's own workspaces and refreshes fail.

Adds an optional `tenant_id` parameter threaded from `self.configuration.parameters` into the token URL:

```python
self.tenant_id = self._resolve_tenant_id(parameters.get(KEY_TENANT_ID))  # blank -> "common"
...
url = f"https://login.microsoftonline.com/{tenant_id or DEFAULT_AUTHORITY}/oauth2/token"
```

Because the authority is applied in `get_oauth_token()`, every path uses the configured tenant: `run()` via `_client_init()`, both `selectWorkspace` / `selectDataset` sync actions via `_client_init()`, and the 403 `TokenExpired` re-auth branch. Blank/missing `tenant_id` produces the byte-identical `/common` URL and no other behaviour change, so existing configurations are unaffected.

`_resolve_tenant_id()` coerces through `str()` (a non-string value written via the API used to raise `AttributeError`) and rejects URL-structured values (pasted authority URL, stray `/`, `?`, `#`) with an actionable `UserException`. Entra accepts both a GUID and a domain name as the authority, so the pattern allows both. Related hardening: the non-200 branch of `_request_new_token` called `response.json()` unguarded — the 404 + empty body that a mis-targeted authority returns turned into `JSONDecodeError` and exit 2; it now falls back to `response.text` / `NO_FAILURE_DETAIL`, matching the refresh-status path.

Schema addition is strictly additive (`required` untouched), at `propertyOrder` 150 — above the workspace/dataset pickers, because it must be set *before* those lists are loaded (they enumerate whichever tenant the token points at, silently and with HTTP 200). Title and description mark it as blank-by-default and guest-only. README documents the B2B guest setup, the load-order caveat, and the re-authorization fallback (an already-authorized configuration redeems the refresh token cached in `state.json`).

Verified: the reporter tested a build of this branch against the real guest-access tenant and confirmed the refresh works, so cross-tenant redemption of the `/common`-issued refresh token works with this app registration. Latest branch image tag for `runtime.tag` testing: `1785940739-tenant-id-authority-51`.

## Release Notes
**Justification, description**

B2B guest accounts could not refresh datasets in the host tenant; the tenant authority is now configurable per configuration.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Backward compatible — new optional parameter defaulting to the current `common` authority; no change for configurations that leave it blank.

**Deployment Plan**

Standard component release.

**Rollback Plan**

Revert the tag. Note that a rollback re-introduces the `/common`-only behaviour, so any configuration relying on `tenant_id` starts failing again.

**Post-Release Support Plan**

N/A


Link to Devin session: https://app.devin.ai/sessions/95a648f25bc4430c95e2eda06cfce7e5
Requested by: @terezaskalova